### PR TITLE
Add configurable EOL display

### DIFF
--- a/smart-mode-line.el
+++ b/smart-mode-line.el
@@ -646,6 +646,11 @@ if you just want to fine-tune it)."
   :group 'smart-mode-line-others
   :package-version '(smart-mode-line . "1.20"))
 
+(defcustom sml/show-eol nil
+  "Whether to display the buffer EOL in the mode-line."
+  :type 'boolean
+  :group 'smart-mode-line-others)
+
 (defcustom sml/outside-modified-char "M"
   "Char to display if buffer needs to be reverted."
   :type 'string
@@ -696,13 +701,18 @@ If you want it to show the backend, just set it to t."
           (line-number-mode  (:eval (propertize sml/numbers-separator  'face 'sml/numbers-separator 'help-echo ,hText))))
          (line-number-mode   (:eval (propertize sml/line-number-format 'face 'sml/line-number       'help-echo ,hText))))))
     
-    ;; Encoding. should we do eol format here? (it's displayed by %Z, but very spacious)
+    ;; Encoding
     (sml/show-encoding
      (:eval (propertize sml/mule-info
                         'face 'sml/mule-info
                         'help-echo 'mode-line-mule-info-help-echo
                         'mouse-face 'mode-line-highlight
                         'local-map mode-line-coding-system-map))) 
+
+    ;; EOL
+    (sml/show-eol
+     (:eval (propertize (mode-line-eol-desc)
+                        'face 'sml/mule-info)))
     
     ;; Modified status
     (:eval


### PR DESCRIPTION
Display EOL using `(mode-line-eol-desc)` according to configured value `sml/show-eol`.
With this, we can change EOL styles by mouse click, which is very useful to me.

Note that I did not specify `:package-version` since I was not sure which version is proper.
