### PR TITLE
Don't try to get the value of unbound symbols

### DIFF
--- a/smart-mode-line.el
+++ b/smart-mode-line.el
@@ -1378,7 +1378,7 @@ duplicated buffer names) from being displayed."
            (kdr (cdr ml)))
        (case (type-of kar)
          ('symbol
-          (let ((val (symbol-value kar))
+          (let ((val (when (boundp kar) (symbol-value kar)))
                 (kadr (if (listp kdr) (car kdr) nil)))
             (case val
               (:eval (sml/mode-list-to-string-list (eval kadr)))


### PR DESCRIPTION
With `doxymacs-mode` installed the error message `Error during redisplay: (eval (sml/generate-minor-modes)) signaled (void-variable doxymacs-mode)` is continuously printed to the message buffer until `doxymacs.el` is loaded since `doxymacs-mode` is registered as a minor mode by autoload but doesn't have a value yet.
