### PR TITLE
Describe a workaround for a safe-themes problem.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To change the color theme, do one of the following:
     (sml/apply-theme 'respectful)
     (sml/apply-theme 'automatic)
 
-#### Instalation Issues (FAQ) ####
+#### Installation Issues (FAQ) ####
 
 - **Problem:** If emacs keeps warning you that *"Loading themes can run
 lisp code"* and asking *"Would you like to mark this theme as safe for
@@ -56,7 +56,8 @@ future sessions?"*. That is probably an issue with your `init.el` or
   the very top of your `.emacs` file. That is the right place for it.
   If that doesn't work, you can work around it with the code `(setq sml/no-confirm-load-theme t)`,
   but we recommend you try to figure out what's wrong with your configs.
-  
+- **Solution B:** `smart-mode-line` ships with multiple themes, and each must be separately marked as safe. And when `sml/apply-theme` is set to `automatic`, it may attempt to load a theme which you haven't previously loaded, causing the *"Would you like to mark this theme as safe..."* question to be asked again -- or, when launching `emacs-server` in daemon mode, causing inexplicably weird crashes. A workaround is to manually cycle through all the themes and say "yes" to mark each of them safe. Your goal is for the `(custom-set-variables ...)` sexp at the top of your `.emacs` to contain at least three different entries under `(custom-safe-themes ...)`.
+
 Features
 ===
 Its main features include:


### PR DESCRIPTION
`(sml/apply-theme ‘automatic)` can attempt to apply a theme that hasn’t been used yet, and so hasn’t been marked safe. Worse, it can do this when launching emacs in `—daemon` mode, leading to **severe** debugging pain — the error message is obscure, it doesn’t provide a line number, `—debug-init` is hard to run when launching in `—daemon` mode, and the problem doesn’t manifest if you launch emacs in a window that loads a theme that you’ve already marked safe. I eventually solved this problem by inspired guesswork. I seek to save others from my fate.

This patch attempts to add a description of the problem and its workaround to the README.md. This is only one option, however. One could also:
- Decide that defaulting `sml/theme` to `automatic` is too unreliable and default it to, say, `respectful` instead. I’d make this argument, having invested two hours of my life that I will never get back.
- Write some code that, on initial install, cycles through all the themes and asks the user to mark each one safe, instead of doing this on-demand.

Thanks for your work on this package!
