### PR TITLE
Better handle clones

### DIFF
--- a/smart-mode-line.el
+++ b/smart-mode-line.el
@@ -871,9 +871,15 @@ If you want it to show the backend, just set it to t."
 (defadvice set-visited-file-name (after sml/after-set-visited-file-name-advice ())
   "Regenerate buffer-identification after `set-visited-file-name'."
   (sml/generate-buffer-identification))
-(defadvice clone-indirect-buffer (after sml/after-clone-indirect-buffer-advice ())
+(defadvice clone-indirect-buffer (around sml/around-clone-indirect-buffer-advice ())
   "Regenerate buffer-identification after `clone-indirect-buffer'"
-  (sml/generate-buffer-identification))
+  (let ((cloned-buffer-file-name buffer-file-name)
+        (clone ad-do-it))
+    (with-current-buffer clone
+      (setq buffer-file-name cloned-buffer-file-name)
+      (set (make-variable-buffer-local 'sml/clone) t)
+      (sml/generate-buffer-identification))
+    clone))
 
 (defvar sml/name-width-old nil "Used for recalculating buffer identification filling only when necessary.")
 (make-variable-buffer-local 'sml/name-width-old)
@@ -1422,13 +1428,15 @@ Uses `sml/show-file-name' to decide between the two.
 
 Unless `sml/strip-N' is nil, prevents the \"<N>\" (used in
 duplicated buffer names) from being displayed."
-  (if (and sml/show-file-name (buffer-file-name))
-      (file-name-nondirectory (buffer-file-name))
-    (if (eq major-mode 'dired-mode)
-        (file-name-nondirectory (directory-file-name default-directory))
-     (if sml/show-trailing-N
-         (buffer-name)
-       (replace-regexp-in-string "<[0-9]+>$" "" (buffer-name))))))
+  (if sml/clone
+      (buffer-name)
+    (if (and sml/show-file-name (buffer-file-name))
+	(file-name-nondirectory (buffer-file-name))
+      (if (eq major-mode 'dired-mode)
+	  (file-name-nondirectory (directory-file-name default-directory))
+	(if sml/show-trailing-N
+	    (buffer-name)
+	  (replace-regexp-in-string "<[0-9]+>$" "" (buffer-name)))))))
 
 (defun sml/fill-width-available ()
   "Return the size available for filling."


### PR DESCRIPTION
The code in pull request #97 allows handling cloned buffer in such a way that the newly-created clone is identified by the default string "filename&lt;N>". This is however not very consistent with the way the original buffer is identified through `sml`: "path/to/filename".

I'm not sure haw this problem should be tackled. This patch is one way of dealing with this (potentially not the best, but I haven't thought of anything else).

It advises `clone-indirect-buffer` so that the newly-created clone:
1. inherits its parent `buffer-file-name`, and
2. is clearly identified by having a non-nil buffer-local `sml/clone` variable.

`sml/buffer-name` then always returns `(buffer-name)` for buffers identified as clones, as a way to disambiguate them from their parent.

As a consequence, with this patch, the generated buffer identifications respectively read:
- path/to/filename
- path/to/filename&lt;N>
