### PR TITLE
visibility for sml/time

### DIFF
--- a/themes/smart-mode-line-powerline-theme.el
+++ b/themes/smart-mode-line-powerline-theme.el
@@ -87,7 +87,7 @@ Mimics the appearance of powerline.")
 
    ;; 0
    `(sml/discharging         ((t :background ,l0 :inherit sml/global :foreground "Red")))
-   `(sml/time                ((t :background ,l0 :inherit sml/modes)))
+   `(sml/time                ((t :background ,l0 :inherit sml/global)))
 
    `(persp-selected-face ((t :foreground "ForestGreen" :inherit sml/filename)))
    `(helm-candidate-number ((t :foreground nil :background nil :inherit sml/filename))))


### PR DESCRIPTION
Level 0 background is black.  sml/time font pulls from l0 for background, but sml/modes for foreground.  sml/modes has a foreground of black.  This uses the settings from sml/col-number, to keep the symmetry of the edges the same.  My powerline shows the buffer size on the far left, but I couldn't find that setting in the file.  I chose the one that is applies to sml/modes, it looked the same.
