### PR TITLE
Set :inverse-video on mode-line to nil in respectful theme

### DIFF
--- a/smart-mode-line-respectful-theme.el
+++ b/smart-mode-line-respectful-theme.el
@@ -33,6 +33,7 @@ Results may vary.")
 
 (custom-theme-set-faces
  'smart-mode-line-respectful
+ '(mode-line-inactive ((t :inverse-video nil)))
  '(mode-line     ((t :inverse-video nil)))
  '(sml/global    ((t :inherit font-lock-preprocessor-face)))
  '(sml/filename  ((t :inherit mode-line-buffer-id)))


### PR DESCRIPTION
#### Summary

When using Sellout's Solarized Dark theme on Emacs Version 24.3 (9.0) on OSX with smart-mode-line-respectful-theme, there were some light grey 'fill'-faces as seen in #87. I noticed that in #87 this problem was fixed for the dark-theme and light-theme with commit 9ec3ef82d95c842548ef098ee4dfe56f4ad4d35c, but I did not see any changes pertaining to respectful-theme.
#### Changes

Set :inverse-video to nil for mode-line in smart-mode-line-respectful-theme.el.
Set :inverse-video to nil for mode-line-inactive also.
#### Before (mode-line)

![beforepic](https://cloud.githubusercontent.com/assets/1482167/5497904/8e85de02-86cb-11e4-8c03-225e04701287.png)
#### After (mode-line)

![afterpic](https://cloud.githubusercontent.com/assets/1482167/5497910/94b9ef66-86cb-11e4-8d43-52bea2d8df87.png)
#### Before (mode-line-inactive)

![before2](https://cloud.githubusercontent.com/assets/1482167/5498256/5ccadbf0-86d1-11e4-90bd-8a80fa507c0c.png)
#### After (mode-line-inactive)

![after2](https://cloud.githubusercontent.com/assets/1482167/5498260/65011d8e-86d1-11e4-850c-cdeaea235955.png)
