### PR TITLE
Add visible marker for modified read-only buffer.

### DIFF
--- a/smart-mode-line.el
+++ b/smart-mode-line.el
@@ -1239,11 +1239,10 @@ Also sets SYMBOL to VALUE."
              (verify-visited-file-modtime (current-buffer))))
     (propertize sml/outside-modified-char 'face 'sml/outside-modified
                 'help-echo "Modified outside Emacs!\nRevert first!"))
-   (buffer-read-only (propertize sml/read-only-char
-                                 'face 'sml/read-only
-                                 'help-echo "Read-Only Buffer"))
    ((buffer-modified-p)
-    (propertize sml/modified-char
+    (propertize (if buffer-read-only
+                    sml/read-only-char
+                  sml/modified-char)
                 'face 'sml/modified
                 'help-echo (if (buffer-file-name)
                                (format-time-string
@@ -1251,6 +1250,9 @@ Also sets SYMBOL to VALUE."
                                 (nth 5 (file-attributes (buffer-file-name))))
                              "Buffer Modified")
                 'local-map '(keymap (mode-line keymap (mouse-1 . save-buffer)))))
+   (buffer-read-only (propertize sml/read-only-char
+                                 'face 'sml/read-only
+                                 'help-echo "Read-Only Buffer"))
    (t (propertize " " 'face 'sml/not-modified))))
 
 (defmacro sml/propertize-position (s face help)


### PR DESCRIPTION
Hi, I really like `smart-mode-line`, I've been trying it out for a few days and it's definitely something I'm gonna keep.

There's one small issue, however, that I'm hoping to address with my patch. Emacs allows for a read-only buffer to be modified and the standard mode line shows this as `%*`. I use this possibility in a package of mine (Ebib), but unfortunately, `smart-mode-line` doesn't represent this status, it just shows the buffer as read-only.

With this patch, `sml/read-only-char` is displayed with `sml/modified` face instead of `sml/read-only-face` if a read-only buffer is modified. The patch switches the `buffer-modified-p` and `buffer-read-only` clauses in the `cond` in `sml/generate-modified-status` and makes the character used in the `buffer-modified-p` clause dependent on the read-only status of the buffer.

I did it this way instead of the other way around (i.e., making the face in the `buffer-read-only` clause dependent on the modified status) because a modified read-only buffer can be saved if it’s visiting a file, so I figured it should have the help text and mouse-1 binding of a normal modified buffer.

Would be great if this patch or something like it could be included. Thanks!
