### PR TITLE
Stop calling `file-attributes` for remote buffers

### DIFF
--- a/smart-mode-line.el
+++ b/smart-mode-line.el
@@ -1244,7 +1244,7 @@ Also sets SYMBOL to VALUE."
                     sml/read-only-char
                   sml/modified-char)
                 'face 'sml/modified
-                'help-echo (if (buffer-file-name)
+                'help-echo (if (and (buffer-file-name) (not (file-remote-p buffer-file-name)))
                                (format-time-string
                                 sml/modified-time-string
                                 (nth 5 (file-attributes (buffer-file-name))))


### PR DESCRIPTION
Hi, just a simple fix for SML making Emacs really slow when editing remote buffers.

With certain TRAMP method (in my case SFTP) and slow connections calling `file-attributes` is expensive, especially when doing it every redraw. For me it makes Emacs almost hang and unusable.

Here is the CPU profile: https://gist.github.com/tungd/a73f5ea4eca49bc43592

Thanks.
