### PR TITLE
Proportional face to reduce mode-line width

### DIFF
--- a/smart-mode-line.el
+++ b/smart-mode-line.el
@@ -705,7 +705,7 @@ if you just want to fine-tune it)."
   :group 'smart-mode-line-mode-list)
 
 ;; Face definitions
-(defface sml/global           '((t :inverse-video nil)) "" :group 'smart-mode-line-faces)
+(defface sml/global           '((t :inverse-video nil :family "Arial")) "" :group 'smart-mode-line-faces)
 (defface sml/modes            '((t :inherit sml/global)) "" :group 'smart-mode-line-faces)
 (defface sml/minor-modes      '((t :inherit sml/global)) "" :group 'smart-mode-line-faces)
 (defface sml/filename         '((t :inherit sml/global :weight bold)) "" :group 'smart-mode-line-faces)


### PR DESCRIPTION
Indeed a silly trick, but if you want a smaller mode-line you can change the face used to a proportional one.
I configured sml/global with 'Arial', because it's in all the computers I use, but perhaps there are better proportional fonts (p.e http://input.fontbureau.com/info/).