### PR TITLE
Consider minor mode separators in computation of fill string; #163

### DIFF
--- a/smart-mode-line.el
+++ b/smart-mode-line.el
@@ -1546,7 +1546,11 @@ duplicated buffer names) from being displayed."
         (add-to-list 'nameList sml/propertized-shorten-mode-string t))
 
       ;; Padding
-      (setq filling (- size (length (format-mode-line nameList))))
+      (setq filling (- size (length (format-mode-line
+                                     (list ""
+                                           'sml/pre-minor-modes-separator
+                                           nameList
+                                           'sml/pos-minor-modes-separator)))))
       (setq filling (make-string (max 0 filling) sml/fill-char))
 
       (if (eq sml/mode-width 'right)


### PR DESCRIPTION
The the variables `sml/pre-minor-modes-separator` and
`sml/pos-minor-modes-separator` both contribute to the minor-modes
string. Therefore their sizes must be taken into account when
computing the fill string, too, otherwise the resulting fill string
and the complete modeline string will be too large (e.g. for powerline
theme).