### PR TITLE
Consider separators in computation of maximal mode width

### DIFF
--- a/smart-mode-line.el
+++ b/smart-mode-line.el
@@ -1520,11 +1520,15 @@ duplicated buffer names) from being displayed."
     (let* (;; The minor-mode-alist
            (nameList (rm--mode-list-as-string-list))
            ;; The size available
-           (size (if (member sml/mode-width '(full right))
-                     ;; Calculate how much width is available
-                     (sml/fill-width-available)
-                   ;; or use what the user requested.
-                   sml/mode-width))
+           (size (- (if (member sml/mode-width '(full right))
+                        ;; Calculate how much width is available
+                        (sml/fill-width-available)
+                      ;; or use what the user requested.
+                      sml/mode-width)
+                    (string-width (format-mode-line
+                                   'sml/pre-minor-modes-separator))
+                    (string-width (format-mode-line
+                                   'sml/pos-minor-modes-separator))))
            ;; Used for counting size.
            (finalNameList (mapconcat 'identity  nameList ""))
            needs-removing filling)
@@ -1546,11 +1550,7 @@ duplicated buffer names) from being displayed."
         (add-to-list 'nameList sml/propertized-shorten-mode-string t))
 
       ;; Padding
-      (setq filling (- size (length (format-mode-line
-                                     (list ""
-                                           'sml/pre-minor-modes-separator
-                                           nameList
-                                           'sml/pos-minor-modes-separator)))))
+      (setq filling (- size (length (format-mode-line nameList))))
       (setq filling (make-string (max 0 filling) sml/fill-char))
 
       (if (eq sml/mode-width 'right)


### PR DESCRIPTION
Because the minor mode separators are added to the minor mode string
when filling, their size must be taken into account when computing the
maximal available width.