### PR TITLE
Solve args-out-of-range by ensuring positive 'size' in sml/generate-minor-modes

### DIFF
--- a/smart-mode-line.el
+++ b/smart-mode-line.el
@@ -1523,21 +1523,22 @@ duplicated buffer names) from being displayed."
     (let* (;; The minor-mode-alist
            (nameList (rm--mode-list-as-string-list))
            ;; The size available
-           (size (- (if (member sml/mode-width '(full right))
-                        ;; Calculate how much width is available
-                        (sml/fill-width-available)
-                      ;; or use what the user requested.
-                      sml/mode-width)
-                    (string-width (format-mode-line
-                                   'sml/pre-minor-modes-separator))
-                    (string-width (format-mode-line
-                                   'sml/pos-minor-modes-separator))))
+           (size (max 0
+                      (- (if (member sml/mode-width '(full right))
+                             ;; Calculate how much width is available
+                             (sml/fill-width-available)
+                           ;; or use what the user requested.
+                           sml/mode-width)
+                         (string-width (format-mode-line
+                                        'sml/pre-minor-modes-separator))
+                         (string-width (format-mode-line
+                                        'sml/pos-minor-modes-separator)))))
            ;; Used for counting size.
            (finalNameList (mapconcat 'identity  nameList ""))
            needs-removing filling)
 
       ;; Calculate whether truncation is necessary.
-      (when (and sml/shorten-modes (> size 0) (> (string-width finalNameList) size))
+      (when (and sml/shorten-modes (> (string-width finalNameList) size))
         ;; We need to remove 1+ "the number of spaces found".
         (setq needs-removing
               (1+

--- a/smart-mode-line.el
+++ b/smart-mode-line.el
@@ -1537,7 +1537,7 @@ duplicated buffer names) from being displayed."
            needs-removing filling)
 
       ;; Calculate whether truncation is necessary.
-      (when (and sml/shorten-modes (> (string-width finalNameList) size))
+      (when (and sml/shorten-modes (> size 0) (> (string-width finalNameList) size))
         ;; We need to remove 1+ "the number of spaces found".
         (setq needs-removing
               (1+


### PR DESCRIPTION
I sometimes get this from the message log:

    Error during redisplay: (eval (sml/generate-minor-modes)) signaled (args-out-of-range "" -8)
 
After hunting down the error, I found that `size` sometimes get a negative value.
When it is passed to `sml/count-occurrences-starting-at`, Emacs signal this error when try to `string-match` from a negative index.

I am not sure why I get negative `size`

           (size (- (if (member sml/mode-width '(full right))
                        ;; Calculate how much width is available
                        (sml/fill-width-available)
                      ;; or use what the user requested.
                      sml/mode-width)
                    (string-width (format-mode-line
                                   'sml/pre-minor-modes-separator))
                    (string-width (format-mode-line
                                   'sml/pos-minor-modes-separator))))

My value of `size` under the `let` part sometimes return `-6` which come from `(- 0 3 3)` where `0` comes from the `if` part and `3` is the length of the separator.
