### PR TITLE
Show current directory in term mode.

### DIFF
--- a/smart-mode-line.el
+++ b/smart-mode-line.el
@@ -1071,6 +1071,10 @@ the mode-line will be setup."
   (add-hook 'comint-output-filter-functions 'sml/generate-buffer-identification)
   (add-hook 'eshell-directory-change-hook 'sml/generate-buffer-identification)
 
+  ;; Term support
+  (advice-add 'term-command-hook :after 'sml/generate-buffer-identification)
+  (advice-add 'term-handle-ansi-terminal-messages :after 'sml/generate-buffer-identification)
+
   ;; Dired overrides the buffer-identification (which we would
   ;; normally respect) but doesn't actually do anything useful with
   ;; it, so we overoverride back.
@@ -1580,7 +1584,7 @@ duplicated buffer names) from being displayed."
     ((eq major-mode 'dired-mode)
      (replace-regexp-in-string "/[^/]*/$" "/" default-directory))
     ((and (symbolp major-mode)
-          (member major-mode '(shell-mode eshell-mode)))
+          (member major-mode '(shell-mode eshell-mode term-mode)))
      default-directory)
     ;; In indirect buffers, buffer-file-name is nil. The correct value is
     ;; retrieved from the base buffer.

--- a/smart-mode-line.el
+++ b/smart-mode-line.el
@@ -1072,8 +1072,11 @@ the mode-line will be setup."
   (add-hook 'eshell-directory-change-hook 'sml/generate-buffer-identification)
 
   ;; Term support
-  (advice-add 'term-command-hook :after 'sml/generate-buffer-identification)
-  (advice-add 'term-handle-ansi-terminal-messages :after 'sml/generate-buffer-identification)
+  (defadvice term-command-hook (after sml/term-advice-1 activate)
+    (sml/generate-buffer-identification))
+
+  (defadvice term-handle-ansi-terminal-messages (after sml/term-advice-2 activate)
+    (sml/generate-buffer-identification))
 
   ;; Dired overrides the buffer-identification (which we would
   ;; normally respect) but doesn't actually do anything useful with


### PR DESCRIPTION
Show the current directory and update it when you cd in term mode, the same as happens in shell mode.

We have to do this using advice because term doesn't provide any hooks for monitoring directory changes. Also, the directory will only update if you have directory tracking set up in your shell, but that's just part of the normal setup for using term.