### PR TITLE
Add variable definition for byte-compile warning

### DIFF
--- a/smart-mode-line.el
+++ b/smart-mode-line.el
@@ -367,6 +367,7 @@ set `sml/override-theme' to nil."
 (defvar erc-track-position-in-mode-line)
 (defvar sml/simplified nil
   "Temporary dynamic variable. Used for filling.")
+(defvar sml/active-background-color)
 
 (defvar sml/-debug nil
   "Whether debugging information should be printed.")


### PR DESCRIPTION
There is a byte-compile warning:

> Warning (bytecomp): reference to free variable ‘sml/active-background-color’ [2 times]

I believe this is will fix it.