### PR TITLE
Check mode-line-percent-position existence for mode-line-position

### DIFF
--- a/smart-mode-line.el
+++ b/smart-mode-line.el
@@ -1415,7 +1415,8 @@ To be used in mapcar and accumulate results."
 
    ;;;; mode-line-position
    ;; Color the position percentage
-   ((sml/is-%p-p el)
+   ((or (sml/is-%p-p el)
+        (and (listp el) (memq 'mode-line-percent-position el)))
     `(sml/position-percentage-format
       (-3 (:propertize (:eval sml/position-percentage-format)
                        local-map ,mode-line-column-line-number-mode-map


### PR DESCRIPTION
Emacs 26 has `mode-line-percent-position` variable in `mode-line-position` instead of raw string "%p".

Maybe related to #217.

http://git.savannah.gnu.org/cgit/emacs.git/commit/?id=b0b02ca7f3e06d0f092df6f81babd1277bf93b0f

