### PR TITLE
Fix warning about using nil instead of unspecified

### DIFF
--- a/smart-mode-line-dark-theme.el
+++ b/smart-mode-line-dark-theme.el
@@ -29,7 +29,7 @@
 
 (custom-theme-set-faces
  'smart-mode-line-dark
- '(mode-line-buffer-id ((t :inherit sml/filename :foreground nil :background nil))) 
+ '(mode-line-buffer-id ((t :inherit sml/filename :foreground "unspecified" :background "unspecified")))
  '(mode-line-inactive ((t :foreground "gray60" :background "#404045" :inverse-video nil)))
  '(mode-line     ((t :foreground "gray60" :background "black" :inverse-video nil)))
  '(sml/global    ((t :foreground "gray50" :inverse-video nil)))
@@ -38,7 +38,7 @@
  '(sml/prefix    ((t :inherit sml/global :foreground "#bf6000")))
  '(sml/read-only ((t :inherit sml/not-modified :foreground "DeepSkyBlue")))
  '(persp-selected-face ((t :foreground "ForestGreen" :inherit sml/filename)))
- '(helm-candidate-number ((t :foreground nil :background nil :inherit sml/filename))))
+ '(helm-candidate-number ((t :foreground "unspecified" :background "unspecified" :inherit sml/filename))))
 
 ;;;###autoload
 (when load-file-name

--- a/smart-mode-line-light-theme.el
+++ b/smart-mode-line-light-theme.el
@@ -29,7 +29,7 @@
 
 (custom-theme-set-faces
  'smart-mode-line-light
- '(mode-line-buffer-id ((t :inherit sml/filename :foreground nil :background nil))) 
+ '(mode-line-buffer-id ((t :inherit sml/filename :foreground "unspecified" :background "unspecified")))
  '(mode-line-inactive ((t :foreground "grey20" :background "#fdf6e3" :inverse-video nil)))
  '(mode-line     ((t :foreground "black" :background "grey85" :inverse-video nil)))
  '(sml/global    ((t :foreground "gray20" :inverse-video nil)))

--- a/smart-mode-line-respectful-theme.el
+++ b/smart-mode-line-respectful-theme.el
@@ -38,7 +38,7 @@ Results may vary.")
  '(sml/filename  ((t :inherit mode-line-buffer-id)))
  '(sml/prefix    ((t :inherit (font-lock-variable-name-face sml/global))))
  '(sml/read-only ((t :inherit (font-lock-type-face sml/not-modified))))
- '(sml/modes     ((t :foreground nil :inherit sml/filename :weight normal))))
+ '(sml/modes     ((t :foreground "unspecified" :inherit sml/filename :weight normal))))
 
 ;;;###autoload
 (when load-file-name


### PR DESCRIPTION
Hi! Minor issue, but Emacs 29.1 (and possibly earlier versions) prints warnings like

```
Warning: setting attribute ‘:background’ of face ‘default’: nil value is invalid, use ‘unspecified’ instead.
```

This change seems to fix it.